### PR TITLE
Add per-folder README documentation (v0.5.1)

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,8 @@
+# .github
+
+This folder contains GitHub-specific configuration for the repository.
+
+## What you’ll find here
+
+- `workflows/`
+  - GitHub Actions pipelines (CI automation) that run on pushes/PRs.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,16 @@
+# .github/workflows
+
+This folder contains **GitHub Actions workflows**.
+
+## What it does
+
+- Defines automated checks that run on GitHub (for example on pull requests or pushes).
+- Typically used for formatting/linting, tests, and builds.
+
+## How to read these files
+
+Each `.yml` file is a separate workflow. Open them to see:
+
+- When they trigger (push, PR, manual)
+- What steps they run
+- Which operating systems / toolchains they use

--- a/circuits/README.md
+++ b/circuits/README.md
@@ -1,0 +1,19 @@
+# circuits
+
+This crate contains the **zero-knowledge circuit code** used by InterLink.
+
+## In plain terms
+
+When InterLink says “we prove something happened on another chain using math”, this folder is where that “math” is implemented as circuits (using Halo2).
+
+## What’s inside
+
+- `src/`
+  - Circuit implementations (currently focused on Merkle-path style proofs and hashing).
+- `tests/`
+  - Circuit tests (Halo2 `MockProver` style tests).
+
+## How it relates to the rest of the repo
+
+- Depends on `interlink-core/` for shared circuit primitives (e.g. hashing chips/config).
+- Used by relayer/core logic to generate and/or verify proofs.

--- a/circuits/src/README.md
+++ b/circuits/src/README.md
@@ -1,0 +1,14 @@
+# circuits/src
+
+Rust source code for the `circuits` crate.
+
+## What you’ll find here
+
+- `lib.rs`
+  - Crate entry point; exports the available circuit modules.
+- `merkle.rs`
+  - A Halo2 circuit that walks a Merkle path and exposes the resulting root as a public input.
+
+## Typical usage
+
+This code is primarily consumed by other crates (for example `interlink-core/` and tooling in `relayer/`) rather than being run as a standalone binary.

--- a/circuits/tests/README.md
+++ b/circuits/tests/README.md
@@ -1,0 +1,11 @@
+# circuits/tests
+
+This folder is for tests for the `circuits` crate.
+
+## In plain terms
+
+These tests ensure the circuits in `circuits/src` satisfy their constraints (i.e., they can be proven/verified and the math matches expectations).
+
+## Notes
+
+Most tests in this repo currently live next to the circuit code under `#[cfg(test)]` modules, but this directory is the conventional place for larger integration-style circuit tests.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,16 @@
+# contracts
+
+This folder contains the **on-chain smart contract code** for InterLink, organized by ecosystem.
+
+## In plain terms
+
+InterLink is cross-chain, so it needs a “gateway” or “hub” program/contract on each chain family. This folder is where those chain-specific pieces live.
+
+## Subfolders
+
+- `evm/`
+  - Solidity contracts for Ethereum and other EVM chains.
+- `solana/`
+  - Anchor program for the Solana “hub”/verification side.
+- `cosmos/`
+  - Rust crate placeholder for a Cosmos/wasm-style gateway (currently minimal scaffold).

--- a/contracts/cosmos/README.md
+++ b/contracts/cosmos/README.md
@@ -1,0 +1,14 @@
+# contracts/cosmos
+
+Cosmos-side contract scaffold.
+
+## Current status
+
+This folder is currently a minimal Rust crate placeholder (it contains a basic `lib.rs` and tests). It does not yet implement a Cosmos gateway contract.
+
+## Intended purpose
+
+Eventually, this directory would hold the Cosmos implementation of an InterLink gateway (for example as a CosmWasm contract), analogous to:
+
+- `contracts/evm/` for EVM chains
+- `contracts/solana/` for the Solana hub

--- a/contracts/cosmos/src/README.md
+++ b/contracts/cosmos/src/README.md
@@ -1,0 +1,12 @@
+# contracts/cosmos/src
+
+Rust source folder for the Cosmos contract scaffold.
+
+## What’s here
+
+- `lib.rs`
+  - Placeholder code and a basic unit test.
+
+## What’s missing (for now)
+
+No CosmWasm contract logic is implemented yet; this is scaffolding for future work.

--- a/contracts/evm/README.md
+++ b/contracts/evm/README.md
@@ -1,0 +1,16 @@
+# contracts/evm
+
+EVM (Solidity) contracts for InterLink.
+
+## What this is
+
+This is the **source-chain gateway (spoke)** side for EVM-compatible chains. It:
+
+- Custodies user funds (ERC-20 or native)
+- Emits canonical events that relayers can watch
+- Accepts “verified message” executions after the hub has validated a proof
+
+## Layout
+
+- `src/`
+  - Solidity contract sources.

--- a/contracts/evm/src/README.md
+++ b/contracts/evm/src/README.md
@@ -1,0 +1,14 @@
+# contracts/evm/src
+
+Solidity source code for the EVM gateway.
+
+## Key file
+
+- `InterlinkGateway.sol`
+  - Main gateway contract.
+  - Emits `MessagePublished` events for relayers.
+  - Executes hub-authorized messages via `executeVerifiedMessage`.
+
+## Important note
+
+The `_verifyHalo2Proof` function currently represents the intended architecture (pairing check via the BN254 precompile) rather than a production-ready verifier implementation.

--- a/contracts/solana/README.md
+++ b/contracts/solana/README.md
@@ -1,0 +1,20 @@
+# contracts/solana
+
+Solana program (Anchor) that acts as the InterLink hub/verification side.
+
+## In plain terms
+
+This program is the on-chain place where relayers submit proofs and where InterLink keeps track of which cross-chain message sequences have been processed.
+
+## Layout
+
+- `src/`
+  - Anchor program entrypoints and account types.
+- `Cargo.toml` / `Cargo.lock`
+  - Rust/Anchor build configuration.
+
+## What it does today
+
+- Initializes a `StateRegistry` account (admin + fee settings + last processed sequence)
+- Accepts `submit_proof` transactions and advances the processed sequence
+- Includes a `buy_back_and_burn` instruction for fee burning mechanics

--- a/contracts/solana/src/README.md
+++ b/contracts/solana/src/README.md
@@ -1,0 +1,16 @@
+# contracts/solana/src
+
+Anchor program source code for the Solana hub.
+
+## Key concepts
+
+- **StateRegistry**
+  - Stores admin, fee rate, and the latest processed cross-chain sequence.
+- **submit_proof**
+  - Relayers submit proof bytes + public inputs, and the program records that a sequence is finalized.
+- **buy_back_and_burn**
+  - Burns a portion of the fee token supply according to the protocol design.
+
+## Verification note
+
+`verify_snark_commitment` is currently a lightweight commitment-consistency check meant to represent the intended verification path.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+# docs
+
+This folder is reserved for project documentation.
+
+## Current status
+
+It’s currently empty in this repo snapshot.
+
+## Suggested contents (when you add them)
+
+- Architecture overviews (how relayers, circuits, and contracts fit together)
+- Setup guides (local dev, testnets)
+- Specs for message formats / proof formats
+- Operational runbooks (monitoring, keys, incident response)

--- a/interlink-core/src/README.md
+++ b/interlink-core/src/README.md
@@ -1,0 +1,20 @@
+# interlink-core/src
+
+Rust source code for the `interlink-core` crate.
+
+## In plain terms
+
+This is the shared “core logic” for InterLink: common types, networking/protocol glue, and relayer/proof plumbing that other crates build on.
+
+## Key files
+
+- `lib.rs`
+  - Public module exports and core traits/types (e.g., `Message`) and `InterlinkError`.
+- `circuit.rs`
+  - Circuit-related primitives used by higher-level circuits (for example Poseidon hashing chips/config).
+- `relayer.rs`
+  - Core relayer logic and configuration types.
+- `network.rs`
+  - Networking primitives used by the system.
+- `main.rs`
+  - A small runnable entry point wiring up a relayer config (useful for local/dev testing).

--- a/relayer/README.md
+++ b/relayer/README.md
@@ -1,0 +1,18 @@
+# relayer
+
+This crate builds the **relayer node** for InterLink.
+
+## In plain terms
+
+Relayers are off-chain workers that:
+
+- Watch a source chain (e.g. an EVM chain) for gateway events
+- Build the required proof(s)
+- Submit proofs and message data to the hub chain (Solana in this repo)
+
+## Layout
+
+- `src/`
+  - The relayer binary entry point.
+- `Cargo.toml`
+  - Dependency config. This crate depends on `interlink-core/`.

--- a/relayer/src/README.md
+++ b/relayer/src/README.md
@@ -1,0 +1,17 @@
+# relayer/src
+
+Source code for the `relayer` binary.
+
+## Key file
+
+- `main.rs`
+  - Creates a `RelayerConfig`, constructs a `Relayer`, and runs it.
+
+## Local/dev expectations
+
+The sample config references:
+
+- A local EVM node websocket at `ws://localhost:8545`
+- Solana devnet RPC
+
+In a real deployment you would replace those values with your target environments and secrets.


### PR DESCRIPTION
- Add README.md files to all source directories explaining purpose and contents
- Include human-readable descriptions for circuits, contracts, relayer, and core modules
- Skip generated/build directories and existing READMEs
- Provide clear cross-references between components